### PR TITLE
bug: use skip bid rate from env vars in skiploop

### DIFF
--- a/src/types/arbitrage/skipLoop.ts
+++ b/src/types/arbitrage/skipLoop.ts
@@ -104,7 +104,7 @@ export class SkipLoop extends MempoolLoop {
 					denom: isNativeAsset(this.offerAssetInfo)
 						? this.offerAssetInfo.native_token.denom
 						: this.offerAssetInfo.token.contract_addr,
-					amount: String(Math.max(Math.round(arbTrade.profit * 0.1), 651)),
+					amount: String(Math.max(Math.round(arbTrade.profit * this.skipBidRate), 651)),
 				},
 			],
 		});


### PR DESCRIPTION
This PR includes a commit to fix #22 
The bot will now use the skip-bid-rate set in the envvar instead of the hardcoded .1 value. 

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-bots/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing (if any).
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly using eslint
