### PR TITLE
bug: wrong denom assignment in skip loop

### DIFF
--- a/src/types/arbitrage/skipLoop.ts
+++ b/src/types/arbitrage/skipLoop.ts
@@ -101,7 +101,7 @@ export class SkipLoop extends MempoolLoop {
 			toAddress: this.botConfig.skipBidWallet,
 			amount: [
 				{
-					denom: this.botConfig.offerAssetInfo,
+					denom: this.botConfig.offerAssetInfo.native_token.denom,
 					amount: String(Math.max(Math.round(arbTrade.profit * this.botConfig.skipBidRate), 651)),
 				},
 			],

--- a/src/types/core/botConfig.ts
+++ b/src/types/core/botConfig.ts
@@ -96,6 +96,7 @@ function validateEnvs(envs: NodeJS.ProcessEnv) {
 	assert(envs.RPC_URL && envs.RPC_URL.includes("http"), `Please set "RPC_URL" in env or ".env" file`);
 	assert(envs.FACTORIES_TO_ROUTERS_MAPPING, `Please set "FACTORIES_TO_ROUTERS_MAPPING" in env or ".env" file`);
 	assert(envs.POOLS, `Please set "POOLS" in env or ".env" file`);
+	assert(envs.FLASHLOAN_ROUTER_ADDRESS, `Please set "FLASHLOAN_ROUTER_ADDRESS" in env, or ".env" file`);
 }
 
 /**


### PR DESCRIPTION
BREAKING: ensure new environment variable FLASHLOAN_ROUTER_ADDRESS in env file

## Description and Motivation
There was a denom error in the skiploop, only discoverable when hitting a trade. This PR Fixes it.

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-bots/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing (if any).
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly using eslint
