### PR TITLE
bug: swap error on wyndex swap message fixed in mempool

### DIFF
--- a/src/types/core/pool.ts
+++ b/src/types/core/pool.ts
@@ -103,7 +103,6 @@ export function applyMempoolTradesOnPools(pools: Array<Pool>, mempoolTrades: Arr
 		if (poolToUpdate) {
 			// a direct swap or send to pool
 			if (isSwapMessage(msg) && trade.offer_asset !== undefined) {
-				// Normal swapmessage
 				applyTradeOnPool(poolToUpdate, trade.offer_asset);
 			} else if (isSendMessage(msg) && trade.offer_asset !== undefined) {
 				applyTradeOnPool(poolToUpdate, trade.offer_asset);
@@ -185,8 +184,6 @@ export function applyMempoolTradesOnPools(pools: Array<Pool>, mempoolTrades: Arr
 					}
 				}
 				if (isWyndDaoSwapOperationsMessages(operations)) {
-					// astropoart router
-
 					for (const operation of operations) {
 						const offerAssetInfo = isWyndDaoNativeAsset(operation.wyndex_swap.offer_asset_info)
 							? { native_token: { denom: operation.wyndex_swap.offer_asset_info.native } }


### PR DESCRIPTION
## Description and Motivation
Most messages from the Wyndex application are contained in a "swap operations" message. However, bots will trade directly on the pool addresses of the wyndex application with a "swap" message. This case was not handled properly in the mempool processing of the bot

## Related Issues
#29 
-
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-bots/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing (if any).
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly using eslint
