### PR TITLE
Feat/pools from routers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ node_modules/
 juno.env
 terra.env
 injective.env
+
+# App specific Pool variables
+pools_*.json
 # Build directory
 out/
 

--- a/src/chains/inj/messages/getOrderbookFlashArbMessages.ts
+++ b/src/chains/inj/messages/getOrderbookFlashArbMessages.ts
@@ -11,7 +11,7 @@ import {
 	toChainPrice,
 } from "../../../core/types/base/asset";
 import { OrderSequence } from "../../../core/types/base/path";
-import { AmmDexName, caclulateSpread, outGivenIn, PairType, Pool } from "../../../core/types/base/pool";
+import { AmmDexName, caclulateSpread, outGivenIn, Pool } from "../../../core/types/base/pool";
 import { OptimalOrderbookTrade } from "../../../core/types/base/trades";
 import { IncreaseAllowanceMessage } from "../../../core/types/messages/allowance";
 import { FlashLoanMessage, WasmMessage } from "../../../core/types/messages/flashloanmessage";
@@ -113,7 +113,7 @@ function getWasmMessages(pool: Pool, _offerAsset: RichAsset) {
 		if (isNativeAsset(offerAssetChain.info)) {
 			msg = <DefaultSwapMessage>{
 				swap: {
-					max_spread: pool.pairType === PairType.pcl ? undefined : "0.1",
+					max_spread: String(spread),
 					offer_asset: {
 						amount: offerAssetChain.amount,
 						info:
@@ -122,14 +122,14 @@ function getWasmMessages(pool: Pool, _offerAsset: RichAsset) {
 								: { native: offerAssetChain.info.native_token.denom },
 					},
 
-					belief_price: pool.pairType === PairType.pcl ? undefined : beliefPriceChain,
+					belief_price: beliefPriceChain,
 				},
 			};
 		} else {
 			const innerSwapMsg: InnerSwapMessage = {
 				swap: {
 					belief_price: beliefPriceChain,
-					max_spread: "0.1",
+					max_spread: String(spread),
 				},
 			};
 			const objJsonStr = JSON.stringify(innerSwapMsg);

--- a/src/core/chainOperator/chainAdapters/cosmjs.ts
+++ b/src/core/chainOperator/chainAdapters/cosmjs.ts
@@ -7,6 +7,7 @@ import { createJsonRpcRequest } from "@cosmjs/tendermint-rpc/build/jsonrpc";
 import { HttpBatchClient, HttpClient } from "@cosmjs/tendermint-rpc/build/rpcclients";
 import { SkipBundleClient } from "@skip-mev/skipjs";
 import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { QueryContractInfoResponse } from "cosmjs-types/cosmwasm/wasm/v1/query";
 
 import { BotConfig } from "../../types/base/configs";
 import { Mempool } from "../../types/base/mempool";
@@ -208,7 +209,7 @@ class CosmjsAdapter implements ChainOperatorInterface {
 	 */
 	public async getNewClients(): Promise<string | void> {
 		let out: string;
-		const TIMEOUTDUR = 60000; // 10 Min timeout if error
+		const TIMEOUTDUR = 1000; // 10 Min timeout if error
 		let n = 0;
 		let urlString: string | undefined;
 		this._timeoutRPCs.set(this._currRpcUrl, Date.now());
@@ -247,6 +248,14 @@ class CosmjsAdapter implements ChainOperatorInterface {
 		console.log("Continue...");
 		this._currRpcUrl = out;
 	}
+
+	/**
+	 *
+	 */
+	async queryContractInfo(address: string): Promise<QueryContractInfoResponse> {
+		return await this._wasmQueryClient.wasm.getContractInfo(address);
+	}
+
 	/**
 	 *
 	 */

--- a/src/core/chainOperator/chainAdapters/injective.ts
+++ b/src/core/chainOperator/chainAdapters/injective.ts
@@ -25,6 +25,7 @@ import { ChainId } from "@injectivelabs/ts-types";
 import { SkipBundleClient } from "@skip-mev/skipjs";
 import { MsgSend as CosmJSMsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
 import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { QueryContractInfoResponse } from "cosmjs-types/cosmwasm/wasm/v1/query";
 import { MsgExecuteContract as CosmJSMsgExecuteContract } from "cosmjs-types/cosmwasm/wasm/v1/tx";
 
 import { BotConfig } from "../../types/base/configs";
@@ -161,6 +162,13 @@ class InjectiveAdapter implements ChainOperatorInterface {
 	async queryMempool(): Promise<Mempool> {
 		const mempoolResult = await this._httpClient.execute(createJsonRpcRequest("unconfirmed_txs"));
 		return mempoolResult.result;
+	}
+
+	/**
+	 *
+	 */
+	async queryContractInfo(address: string): Promise<QueryContractInfoResponse> {
+		return await this._wasmQueryClient.wasm.getContractInfo(address);
 	}
 	/**
 	 *

--- a/src/core/chainOperator/chainoperator.ts
+++ b/src/core/chainOperator/chainoperator.ts
@@ -3,6 +3,7 @@ import { EncodeObject } from "@cosmjs/proto-signing";
 import { StdFee } from "@cosmjs/stargate";
 import { Network } from "@injectivelabs/networks";
 import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { QueryContractInfoResponse } from "cosmjs-types/cosmwasm/wasm/v1/query";
 
 import { BotConfig } from "../types/base/configs";
 import CosmjsAdapter from "./chainAdapters/cosmjs";
@@ -70,6 +71,12 @@ export class ChainOperator {
 		}
 	}
 
+	/**
+	 *
+	 */
+	async queryContractInfo(address: string): Promise<QueryContractInfoResponse> {
+		return await this.client.queryContractInfo(address);
+	}
 	/**
 	 *
 	 */

--- a/src/core/types/arbitrageloops/loops/dexMempoolloop.ts
+++ b/src/core/types/arbitrageloops/loops/dexMempoolloop.ts
@@ -51,7 +51,9 @@ export class DexMempoolLoop implements DexLoopInterface {
 		updateOrderbookStates?: DexLoopInterface["updateOrderbookStates"],
 	) {
 		const paths = getAmmPaths(allPools, botConfig);
+
 		const filteredPools = removedUnusedPools(allPools, paths);
+		console.log(`all pools: ${allPools.length}, filtered pools: ${filteredPools.length}`);
 		const orderbookPaths = getOrderbookAmmPaths(allPools, orderbooks, botConfig);
 		const filteredOrderbooks = removedUnusedOrderbooks(orderbooks, orderbookPaths);
 		this.orderbookPaths = orderbookPaths;

--- a/src/core/types/arbitrageloops/loops/dexloop.ts
+++ b/src/core/types/arbitrageloops/loops/dexloop.ts
@@ -1,7 +1,9 @@
+import * as fs from "fs/promises";
+
 import * as chains from "../../../../chains";
 import { messageFactory } from "../../../../chains/defaults/messages/messageFactory";
 import { tryAmmArb, tryOrderbookArb } from "../../../arbitrage/arbitrage";
-import {} from "../../../arbitrage/optimizers/orderbookOptimizer";
+import { } from "../../../arbitrage/optimizers/orderbookOptimizer";
 import { ChainOperator } from "../../../chainOperator/chainoperator";
 import { Logger } from "../../../logging";
 import { DexConfig } from "../../base/configs";
@@ -98,13 +100,39 @@ export class DexLoop implements DexLoopInterface {
 				orderbooks.push(...obs);
 			}
 		}
-		const allPools = await initPools(
-			chainOperator,
-			botConfig.poolEnvs,
-			botConfig.mappingFactoryRouter,
-			botConfig.manualPoolsOnly,
-		);
 
+		//read pools from file if exists, else initialise them again and store
+		/********************************************************************* */
+		let allPools: Array<Pool>;
+		try {
+			// reading a JSON file synchronously
+			const allPoolsData = await fs.readFile(`./src/envs/storage/pools_${botConfig.chainPrefix}.json`, {
+				encoding: "utf-8",
+			});
+
+			allPools = JSON.parse(allPoolsData);
+			console.log(`pool data found in "./src/envs/storage/pools_${botConfig.chainPrefix}.json", re-using these`);
+		} catch (error) {
+			// cannot find stored pools
+			console.log(
+				`pool data not found in "./src/envs/storage/pools_${botConfig.chainPrefix}.json", initialiasing all pools`,
+			);
+			allPools = await initPools(
+				chainOperator,
+				botConfig.poolEnvs,
+				botConfig.mappingFactoryRouter,
+				botConfig.manualPoolsOnly,
+			);
+
+			console.log(`storing pools as  "./src/envs/storage/pools_${botConfig.chainPrefix}.json"`);
+			// writing the JSON string content to a file
+			await fs.writeFile(`./src/envs/storage/pools_${botConfig.chainPrefix}.json`, JSON.stringify(allPools));
+			// throwing the error
+		}
+		/********************************************************************* */
+
+		//Initialise correct loop based on read config
+		/********************************************************************* */
 		if (botConfig.useMempool && !botConfig.skipConfig?.useSkip) {
 			console.log("spinning up mempool loop");
 			return new DexMempoolLoop(

--- a/src/core/types/arbitrageloops/loops/dexloop.ts
+++ b/src/core/types/arbitrageloops/loops/dexloop.ts
@@ -98,7 +98,12 @@ export class DexLoop implements DexLoopInterface {
 				orderbooks.push(...obs);
 			}
 		}
-		const allPools = await initPools(chainOperator, botConfig.poolEnvs, botConfig.mappingFactoryRouter);
+		const allPools = await initPools(
+			chainOperator,
+			botConfig.poolEnvs,
+			botConfig.mappingFactoryRouter,
+			botConfig.manualPoolsOnly,
+		);
 
 		if (botConfig.useMempool && !botConfig.skipConfig?.useSkip) {
 			console.log("spinning up mempool loop");

--- a/src/core/types/base/configs.ts
+++ b/src/core/types/base/configs.ts
@@ -55,6 +55,7 @@ export interface DexConfig extends BaseConfig {
 	mappingFactoryRouter: Array<{ factory: string; router: string }>;
 	offerAssetInfo: NativeAssetInfo;
 	poolEnvs: Array<{ pool: string; inputfee: number; outputfee: number; LPratio: number }>;
+	manualPoolsOnly: boolean;
 	orderbooks: Array<string>;
 	timeoutDuration: number;
 	useRpcUrlScraper?: boolean;
@@ -222,6 +223,7 @@ function getDexConfig(envs: NodeJS.ProcessEnv, baseConfig: BaseConfig): DexConfi
 		mappingFactoryRouter: FACTORIES_TO_ROUTERS_MAPPING,
 		offerAssetInfo: OFFER_ASSET_INFO,
 		poolEnvs: POOLS_ENVS,
+		manualPoolsOnly: envs.MANUAL_POOLS_ONLY == "1" ? true : false,
 		orderbooks: orderbooks ?? [],
 		timeoutDuration: timeoutDuration,
 		useRpcUrlScraper: envs.USE_RPC_URL_SCRAPER == "1" ? true : false,

--- a/src/core/types/modules.d.ts
+++ b/src/core/types/modules.d.ts
@@ -70,6 +70,11 @@ declare namespace NodeJS {
 		 */
 		POOLS: string;
 		/**
+		 * Whether we query the pool factory to get all existing pools or only use the manually entered pools.
+		 */
+		MANUAL_POOLS_ONLY: string;
+
+		/**
 		 * A list of all known orderbook pairs (marketids), only relevant when SETUP_TYPE = dex.
 		 */
 		ORDERBOOKS: string;

--- a/src/tests/core/types/base/pool.spec.ts
+++ b/src/tests/core/types/base/pool.spec.ts
@@ -1,19 +1,13 @@
-import { setupWasmExtension } from "@cosmjs/cosmwasm-stargate";
-import { fromAscii, fromBase64 } from "@cosmjs/encoding";
-import { QueryClient } from "@cosmjs/stargate";
-import { HttpBatchClient, Tendermint34Client } from "@cosmjs/tendermint-rpc";
-import { doesNotMatch } from "assert";
 import BigNumber from "bignumber.js";
 import { assert, expect } from "chai";
 import dotenv from "dotenv";
 import { describe } from "mocha";
 
-import { initPools, processPoolStateAssets } from "../../../../chains/defaults/queries/getPoolState";
+import { initPools } from "../../../../chains/defaults/queries/getPoolState";
 import { ChainOperator } from "../../../../core/chainOperator/chainoperator";
 import { Asset, fromChainAsset, RichAsset, toChainAsset } from "../../../../core/types/base/asset";
 import { DexConfig, setBotConfig } from "../../../../core/types/base/configs";
-import { AmmDexName, outGivenIn, PairType, PCLPool, Pool } from "../../../../core/types/base/pool";
-import { Uint128 } from "../../../../core/types/base/uint128";
+import { AmmDexName, outGivenIn, PairType, Pool } from "../../../../core/types/base/pool";
 import { identity } from "../../../../core/types/identity";
 
 dotenv.config({ path: "./src/envs/chains/injective.env" });
@@ -168,7 +162,6 @@ describe("Test outGivenIn", () => {
 });
 
 describe("Test PCL Pool interactions", () => {
-
 	it("should be able to calculate outgivenin for PCL pools", async () => {
 		// load config required for querying
 		dotenv.config({ path: "./src/tests/mock/envs/injective.env" });
@@ -179,34 +172,27 @@ describe("Test PCL Pool interactions", () => {
 		const pclPool = pools.find((pool) => pool.pairType === PairType.pcl);
 
 		expect(botConfig, "botconfig empty").to.not.be.undefined;
-		expect(chainOperator, "chainoperator issue").to.not.be.undefined
+		expect(chainOperator, "chainoperator issue").to.not.be.undefined;
 		expect(pclPool, "PCL pool not found").to.not.be.undefined;
 		if (!pclPool) {
-			return
+			return;
 		}
 
 		for (const poolAsset of pclPool.assets) {
 			const offerAsset: RichAsset = {
 				info: poolAsset.info,
 				decimals: poolAsset.decimals,
-				amount: "10000000"
-			}
+				amount: "10000000",
+			};
 
 			const out0 = outGivenIn(pclPool, offerAsset);
 			const chainAsset: Asset = toChainAsset(offerAsset);
-			const simulatedResult = await chainOperator.queryContractSmart(
-				pclPool.address,
-				{ simulation: { offer_asset: chainAsset } },
-			);
+			const simulatedResult = await chainOperator.queryContractSmart(pclPool.address, {
+				simulation: { offer_asset: chainAsset },
+			});
 			const outSimulatedAsset = fromChainAsset({ amount: simulatedResult.return_amount, info: out0.info });
 			assert.closeTo(+out0.amount, +outSimulatedAsset.amount, 1);
 		}
-
-
-
-
-
-
 	});
 });
 


### PR DESCRIPTION
## Description and Motivation

This PR adds querying factories for all existing pools to the bots. It adds a few checks for the pools before they get added to the list of allPools, and pools get removed from the bot when they are not part of any Path, to save querying time. 
Also, this PR adds saving/reading the POOLS variable from the filesystem if present, again, to save a lot of startup-time. 
Finally, an environment variable called `MANUAL_POOLS_ONLY` is added to the botConfig (defaulting to 0) that allows users to **not** query the factories for all pools but only using the manually entered pools in the POOLS variable, this to allow dedicated bots for specific pools/paths. 

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/white-whale-bots/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing (if any).
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly using eslint
